### PR TITLE
pin uptime-monitor@v1.26.1 in update-template.yml

### DIFF
--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}
       - name: Update template
-        uses: upptime/uptime-monitor@master
+        uses: upptime/uptime-monitor@v1.26.1
         with:
           command: "update-template"
         env:


### PR DESCRIPTION
All other references in repo uses: `upptime/uptime-monitor@v1.26.1` while the one in update-template.yml uses: `upptime/uptime-monitor@master`

Currently, there are 15 commits to upptime/uptime-monitor master since 1.26.1 so there must be a change in behavior somewhere in those commits. 

This should help with #286 because I am get the error when I manually trigger Update Template CI (uptime-monitor@master), but not when I manually trigger Setup CI (uptime-monitor@1.26.1).