### PR TITLE
Renamed koj-co to pabio

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
       - name: Run readme-repos-list
-        uses: koj-co/readme-repos-list@master
+        uses: pabio/readme-repos-list@master
         with:
           token: ${{ secrets.GH_PAT }}
           query: "topic:upptime"


### PR DESCRIPTION
Upptime uses an action from koj-co, but he/she renamed the username to pabio. So renaming it here as well so that the workflow will work again.