### PR TITLE
Remove PT-BR translation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Upptime is used by [**1,000+**](https://github.com/topics/upptime) people and te
 
 <!--start: docs-->
 
-_This README is also available in [🇧🇷 Brazilian Portuguese](./README.pt-br.md)_
-
 ## ⭐ How it works
 
 - GitHub Actions is used as an uptime monitor


### PR DESCRIPTION
I hope I can change this section without it being overridden again...

Either way, the mentioned PT-BR translation no longer exists, leading to a 404 page.