### PR TITLE
Update workflow versions

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}
@@ -55,7 +55,7 @@ jobs:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
-      - uses: peaceiris/actions-gh-pages@v3.7.3
+      - uses: peaceiris/actions-gh-pages@v3.8.0
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,7 +21,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}
@@ -31,7 +31,7 @@ jobs:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
-      - uses: peaceiris/actions-gh-pages@v3.7.3
+      - uses: peaceiris/actions-gh-pages@v3.8.0
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
I hope I put this in the right place...

Bumps the versions of the checkout and gh-pages action to their latest versions available.
To my knowledge are there no breaking changes that require a change in configuration.

Closes #567 