### PR TITLE
Fixed link to example issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ _Upptime is not affiliated to or endorsed by GitHub._
 
 #### Issues as incidents
 
-When the GitHub Actions workflow detects that one of your URLs is down, it automatically opens a GitHub issue ([example issue #15](https://github.com/koj-co/upptime/issues/15)). You can add incident reports to this issue by adding comments. When your site comes back up, the issue will be closed automatically as well.
+When the GitHub Actions workflow detects that one of your URLs is down, it automatically opens a GitHub issue ([example issue #67](https://github.com/upptime/upptime/issues/67)). You can add incident reports to this issue by adding comments. When your site comes back up, the issue will be closed automatically as well.
 
 <table>
   <tr>


### PR DESCRIPTION
Very small PR, to fix a broken link. In the readme, under the [Issues as Incidents](https://github.com/upptime/upptime#issues-as-incidents) section, the URL to the example issue returns a 404.

The previous ticket [#15](https://github.com/upptime/upptime/issues/15) looks to have been deleted, but there's a working example issue in [#67](https://github.com/upptime/upptime/issues/67), so this PR just updates that link accordingly.

I guess that happened when the repo was transferred from `https://github.com/koj-co/upptime/` to `https://github.com/upptime/upptime`

P.s - I love upptime, it's an awesome project, thank you @AnandChowdhary and team for developing and maintaining it :)