### PR TITLE
feat: added support for IPv6 in GitHub Actions

### DIFF
--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      # This is necessary because GitHub Actions does not support IPv6 yet
+      # And if a user has `ipv6: true` set in their yaml config, it wouldn't work otherwise
+      # <https://github.com/actions/runner-images/issues/668#issuecomment-1872487355>
+      - name: Setup WARP
+        uses: fscarmen/warp-on-actions@v2
       - name: Update response time
         uses: upptime/uptime-monitor@v1.35.0
         with:


### PR DESCRIPTION
Recently we submitted a PR for adding `ipv6: true` to the yaml config to check IPv6.  However GitHub actions does not yet support IPv6 unfortunately.  This PR is necessary as it uses Cloudflare WARP network configuration on the runner to add IPv6 support.  See <https://github.com/actions/runner-images/issues/668#issuecomment-1872487355> for more insight.