### PR TITLE
refactor: Update links to organization discussions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: 'AnandChowdhary'
 
 ---
 
-<!-- If you have a question, you should use Discussions instead: https://github.com/upptime/upptime/discussions -->
+<!-- If you have a question, you should use Discussions instead: https://github.com/orgs/upptime/discussions -->
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Feature requests and ideas
-    url: https://github.com/upptime/upptime/discussions/new?category=ideas
+    url: https://github.com/orgs/upptime/discussions/new?category=ideas
     about: Suggest an idea for this project
   - name: Questions
-    url: https://github.com/upptime/upptime/discussions/new?category=q-a
+    url: https://github.com/orgs/upptime/discussions/new?category=q-a
     about: Please ask and answer questions here


### PR DESCRIPTION
Update the links to organization discussions in the issue templates for feature requests and ideas as well as for bug reports. The new links now point to the organization discussions instead of the upptime repo discussions which don't exist.