### PR TITLE
fix: serialize Upptime workflow pushes

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -15,6 +15,9 @@
 
 
 name: Graphs CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -29,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
         uses: upptime/uptime-monitor@v1.41.3

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -15,6 +15,9 @@
 
 
 name: Response Time CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   schedule:
     - cron: "0 23 * * *"
@@ -29,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@v1.41.3

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -15,6 +15,9 @@
 
 
 name: Setup CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   push:
     paths:
@@ -30,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
         uses: upptime/uptime-monitor@v1.41.3

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -15,6 +15,9 @@
 
 
 name: Static Site CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   schedule:
     - cron: "0 1 * * *"
@@ -30,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
         uses: upptime/uptime-monitor@v1.41.3

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -15,6 +15,9 @@
 
 
 name: Summary CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -29,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@v1.41.3

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -15,6 +15,9 @@
 
 
 name: Update Template CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -29,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
         uses: upptime/uptime-monitor@master

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,6 +15,9 @@
 
 
 name: Updates CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   schedule:
     - cron: "0 3 * * *"
@@ -29,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update code
         uses: upptime/updates@master

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -15,6 +15,9 @@
 
 
 name: Uptime CI
+concurrency:
+  group: upptime-${{ github.repository }}-${{ github.ref_name || github.event.repository.default_branch }}
+  cancel-in-progress: false
 on:
   schedule:
     - cron: "*/5 * * * *"
@@ -29,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
         uses: upptime/uptime-monitor@v1.41.3


### PR DESCRIPTION
## Summary
- Serializes the branch-mutating Upptime workflows with a shared per-repo/per-branch concurrency group.
- Checks out the current branch name for scheduled/dispatch runs instead of the event's stale head SHA.
- Prevents concurrent generated-file commits from racing and producing non-fast-forward push failures.

Fixes #1159

## Test Plan
- `python3` YAML parse for all `.github/workflows/*.yml`
- `/tmp/actionlint-oss/actionlint .github/workflows/*.yml`
- workflow consistency script verifying all workflows share the same concurrency group and checkout ref fallback
- `git diff --cached --check`
- added-line security scan: no findings
