### PR TITLE
:bug: Update generated workflows to checkout v5

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -28,7 +28,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}


### PR DESCRIPTION
## Summary
- Updates all generated Upptime template workflows from `actions/checkout@v4` to `actions/checkout@v5`.
- Keeps the change focused on the remaining Node 20 action deprecation warning; `@v5` is the minimal checkout major that runs on Node 24.

Fixes #1142

## Test plan
- Verified with the GitHub API that `actions/checkout@v5` exists and its `action.yml` runs on `node24`.
- Parsed all `.github/workflows/*.yml` files with PyYAML.
- Confirmed there are no remaining `actions/checkout@v4` refs in generated workflows.
- Ran added-line security scan.
