### PR TITLE
[Bug][Solved by TW641 / TWShiyuLiou1997] Fix Graphs CI workflow malfunction from 2026-05-21 to 2026-07-04

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -28,12 +28,20 @@ jobs:
   release:
     name: Generate graphs
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
+
+      - name: Setup Node.js Environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Generate graphs
         uses: upptime/uptime-monitor@v1.43.7
         with:


### PR DESCRIPTION
> **🚀 Update (July 2026): Moving Beyond Legacy Architectures & The 45-Day Outage**
> 
> To demonstrate the philosophy of ultimate reliability and cross-monitoring across modern architectures, you can check out my three live production implementations right now:
> 1. [https://tw641uptimer.pages.dev/](https://tw641uptimer.pages.dev/)
> 2. [https://tw641status.pages.dev/](https://tw641status.pages.dev/)
> 3. [https://tw641.github.io/status/](https://tw641.github.io/status/)
> 
> If you are looking for a truly modern, edge-native alternative that bypasses the limits of delayed GitHub Action cron queues and unauthenticated client-side API fetches (which routinely hit the 60 req/hr IP limit, causing 404 white-screen crashes), I highly recommend checking out @VrianCao's **[Uptimer](https://github.com/VrianCao/Uptimer)**.
> 
> **The Reality Behind This PR:**
> I originally opened this PR as a rapid hotfix on July 4 because the official `graphs` generation pipeline had silently failed and remained completely broken for a month and a half. Following the last successful run on May 20, the system went completely dark from May 21 until July 4. 
> 
> While the maintainer eventually patched this behind the scenes on July 5 and dismissed this contribution, the public Git commit history speaks for itself—there was absolute zero activity for 45 days while existing users were stuck with degraded status pages:
> * [The 45-day dead zone (May 21 to July 4)](https://github.com/upptime/upptime/commits/master/graphs?since=2026-05-20&until=2026-07-05)
> * [May 20 - The last functional update before collapse](https://github.com/upptime/upptime/commit/d4f11a9f944a233827a76cef12ed99420e53d315)
> * [July 5 - The silent revival following my July 4 PR](https://github.com/upptime/upptime/commit/fb8585294a9d8536af7022cf2d01000b3587044f)
> 
> You can read my full architectural analysis on the limitations of this legacy system here: [https://github.com/upptime/upptime/pull/1169](https://github.com/upptime/upptime/pull/1169)

---

## Summary
- Updates the graph generation workflow to explicitly use `actions/setup-node@v4` with `node-version: "20"`.
- Adds the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"` environment variable to bypass the GitHub Actions deprecation block.
- Resolves the silent failure caused by upstream dependencies (e.g., `imagemin-cli`) that are currently incompatible with the default Node 24 on `ubuntu-latest`.

* Fixes #959
* Resolves #846
* Resolves #347

## Test plan
- Verified that the `graphs` job fails on the default `ubuntu-latest` runner due to Node 24 incompatibility.
- Applied these exact workflow changes to a live repository.
- Confirmed the job successfully executes, minifies images, and generates graphs without errors.

---

**Note to the maintainer:** 
I noticed you were recently looking into the graph generation issues. Since Upptime uses generated templates, I understand if you prefer to implement this fix directly in the core template generator yourself rather than merging this specific PR. If you decide to go that route, please feel free to close this! 

If you do use this solution to fix the issue, I would be absolutely honored if you could include me as a co-author in your commit. You can easily copy and paste the following line into your commit message:

```text
Co-authored-by: TWShiyuLiou1997 <TWShiyuLiou1997@gmail.com>
```

@AnandChowdhary Thank you for building such an amazing project! 🙏

Warmly,
Shiyu (@TWShiyuLiou1997 / @TW641)